### PR TITLE
Tweak the default package to avoid smithy4s

### DIFF
--- a/mill/service/smithy/MyApi.smithy
+++ b/mill/service/smithy/MyApi.smithy
@@ -1,6 +1,6 @@
 \$version: "2"
 
-namespace smithy4s.hello
+namespace com.example.hello
 
 use alloy#simpleRestJson
 

--- a/mill/service/src/com/example/Main.scala
+++ b/mill/service/src/com/example/Main.scala
@@ -1,6 +1,6 @@
 package com.example
 
-import smithy4s.hello._
+import com.example.hello._
 import cats.effect._
 import cats.implicits._
 import org.http4s.implicits._

--- a/src/main/g8/src/main/scala/com/example/Main.scala
+++ b/src/main/g8/src/main/scala/com/example/Main.scala
@@ -1,6 +1,6 @@
 package com.example
 
-import smithy4s.hello._
+import com.example.hello._
 import cats.effect._
 import cats.implicits._
 import org.http4s.implicits._

--- a/src/main/g8/src/main/smithy/MyApi.smithy
+++ b/src/main/g8/src/main/smithy/MyApi.smithy
@@ -1,6 +1,6 @@
 \$version: "2"
 
-namespace smithy4s.hello
+namespace com.example.hello
 
 use alloy#simpleRestJson
 


### PR DESCRIPTION
In a personal project, it conflicted when I imported a smithy4s dependency. So I realized smithy4s.hello might not be the best default value