### PR TITLE
Update scala to 2.13.12

### DIFF
--- a/src/main/g8/$if(mill.truthy)$.$endif$/build.sc
+++ b/src/main/g8/$if(mill.truthy)$.$endif$/build.sc
@@ -8,7 +8,7 @@ object service extends SbtModule with Smithy4sModule {
   def millSourcePath = os.pwd
   def smithy4sInputDirs = T.sources(millSourcePath / "src" / "main" / "smithy")
 
-  def scalaVersion = "2.13.9"
+  def scalaVersion = "2.13.12"
   override def ivyDeps = Agg(
     ivy"com.disneystreaming.smithy4s::smithy4s-core:\${smithy4sVersion()}",
     ivy"com.disneystreaming.smithy4s::smithy4s-http4s-swagger:\${smithy4sVersion()}",

--- a/src/main/g8/$if(sbt.truthy)$.$endif$/build.sbt
+++ b/src/main/g8/$if(sbt.truthy)$.$endif$/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.9"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / organization := "com.example"
 ThisBuild / organizationName := "example"


### PR DESCRIPTION
This PR bumps the version of Scala to 2.13.12.

Without this, I was running into an error on `sbt run`:

```
error: scala.reflect.internal.FatalError:                                                                                                                                  
  bad constant pool index: 0 at pos: 48445
...
Error compiling the sbt component 'compiler-bridge_2.13'
```