### PR TITLE
Set dependency cooldown as a precaution against avoidable supply chain attacks

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,3 +4,6 @@ updates.fileExtensions = [
   "src/main/g8/$if(sbt.truthy)$.$endif$/build.sbt",
   "src/main/g8/smithy-build.json",
 ]
+updates.cooldown = {
+  minimumAge = "7 days"
+}


### PR DESCRIPTION


Context: https://github.com/scala-steward-org/scala-steward/pull/3762